### PR TITLE
Issue#2

### DIFF
--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button, Spin } from "antd";
+import { Button, Spin, Popover } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 // Auto generate button label
 import {
@@ -21,8 +21,6 @@ import { CurrencyInput } from "./currencyInput";
 // Opertions on the pool
 import { addLiquidity, PoolForBasketPromise, usePoolForBasket, calculateDependentAmount, PoolOperation } from '../utils/pools';
 import { useMint } from '../utils/accounts';
-
-import { useCurrencyPairState } from "../utils/currencyPair";
 // Make notifications
 import { notify } from '../utils/notifications'
 // 
@@ -165,6 +163,16 @@ export const AddLiquidityView = (props: {
   return (
     <>
       <div>
+        <Popover
+          trigger="hover"
+          content={
+            <div style={{ width: 300 }}>
+              Provide Liquidity to pool in one step.
+            </div>
+          }
+        >
+          <Button type="text">What is this.</Button>
+        </Popover>
         <CurrencyInput
           title="Input"
           onInputChange={(val: any) => {
@@ -194,7 +202,7 @@ export const AddLiquidityView = (props: {
               !hasSufficientBalance)
           }
         >
-          {generateActionLabel(ADD_LIQUIDITY_LABEL, connected, tokenMap, baseMintAddress, outcome0)}
+          {generateActionLabel(ADD_LIQUIDITY_LABEL, connected, tokenMap, baseMintAddress, baseMintAddress)}
           {pendingTx && <Spin indicator={antIcon} className="add-spinner" />}
         </Button>
 

--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -163,16 +163,33 @@ export const AddLiquidityView = (props: {
   return (
     <>
       <div>
-        <Popover
-          trigger="hover"
-          content={
-            <div style={{ width: 300 }}>
-              Provide Liquidity to pool in one step.
+        <div>
+          <Popover
+            trigger="hover"
+            content={
+              <div style={{ width: 300 }}>
+                Provide Liquidity to pool in one step.
             </div>
-          }
-        >
-          <Button type="text">What is this.</Button>
-        </Popover>
+            }
+          >
+            <Button type="text">What is this.</Button>
+          </Popover>
+        </div>
+        <div>
+          <Popover
+            trigger="hover"
+            content={
+              <div style={{ width: 300 }}>
+                Liquidity providers earn a fixed percentage fee on all trades
+                proportional to their share of the pool. Fees are added to the
+                pool, accrue in real time and can be claimed by withdrawing your
+                liquidity.
+            </div>
+            }
+          >
+            <Button type="text">Read more about providing liquidity.</Button>
+          </Popover>
+        </div>
         <CurrencyInput
           title="Input"
           onInputChange={(val: any) => {

--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -109,6 +109,15 @@ export const AddLiquidityView = (props: {
           // @ts-ignore
           issueSet(props.market, parseAmount(baseMint, baseMintAddress.amount) / 2, wallet, connection)
             .then(async () => {
+              // Check that the outcome token accounts exists
+              if (!outcome0.account || !outcome1.account) {
+                notify({
+                  description:
+                    "Token account does not exists",
+                  message: "Adding liquidity cancelled.",
+                  type: "error",
+                });
+              }
               pendingTxNum -= 1;
               // Fund pools of the outcome pk
               [outcome0, outcome1].forEach(async (outcome, i) => {

--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -212,8 +212,6 @@ export const AddLiquidityView = (props: {
             connected &&
             (pendingTx ||
               !baseMintAddress.account ||
-              !outcome0.account ||
-              !outcome1.account ||
               baseMintAddress.account === outcome1.account ||
               baseMintAddress.account === outcome1.account ||
               !hasSufficientBalance)

--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from "react";
+import { Button, Spin, Select } from "antd";
+import { LoadingOutlined } from "@ant-design/icons";
+// Auto generate button label
+import {
+  ADD_LIQUIDITY_LABEL,
+  generateActionLabel,
+} from "./labels";
+// Issue set helper
+import issueSet from '../utils/issueSet';
+import { markets } from "../markets";
+// Connect to wallet
+import { useWallet } from '../utils/wallet';
+// Create connection to wallet
+import {
+  useConnection, useConnectionConfig, useSlippageConfig
+} from '../utils/connection';
+// Our contract details
+import contract_keys from "../contract_keys.json";
+import { useMint } from '../utils/accounts';
+// Currency pair on this market
+import { useCurrencyPairState } from "../utils/currencyPair";
+// Input box
+import { CurrencyInput } from "./currencyInput";
+// Opertions on the pool
+import { PoolOperation, addLiquidity, usePoolForBasket } from '../utils/pools';
+// Make notifications
+import { notify } from '../utils/notifications'
+// 
+import { DEFAULT_DENOMINATOR } from "./pool/config";
+import { PoolConfig } from "../models";
+// Token Icons
+import { TokenIcon } from "./tokenIcon";
+
+// Create icons
+const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
+const { Option } = Select;
+
+// TODO: Allow market change
+// TODO: Check for no pool
+// TODO: Only allow usdc account
+export const AddLiquidityView = (props: {}) => {
+  const connection = useConnection();
+  const { wallet, connected } = useWallet();
+  const [pendingTx, setPendingTx] = useState(false);
+  // The mint address public key
+  const quoteMint = useMint(contract_keys.quote_mint_pk);
+  const {
+    A,
+    B,
+    setPoolOperation,
+    setLastTypedAccount
+  } = useCurrencyPairState();
+  const pool = usePoolForBasket([A?.mintAddress, B?.mintAddress]);
+  const { tokens, tokenMap } = useConnectionConfig();
+  const { slippage } = useSlippageConfig();
+  const [options, setOptions] = useState<PoolConfig>({
+    curveType: 0,
+    tradeFeeNumerator: 25,
+    tradeFeeDenominator: DEFAULT_DENOMINATOR,
+    ownerTradeFeeNumerator: 5,
+    ownerTradeFeeDenominator: DEFAULT_DENOMINATOR,
+    ownerWithdrawFeeNumerator: 0,
+    ownerWithdrawFeeDenominator: DEFAULT_DENOMINATOR,
+  });
+
+  const parseAmount = (amount: any) => {
+    if (quoteMint) {
+      try {
+        return parseFloat(amount) * Math.pow(10, quoteMint.decimals);
+      } catch (error) {
+        // TODOl WHat to do here
+      }
+    } else {
+      // TODO: What to do here
+    }
+  }
+
+  const hasSufficientBalance = A.sufficientBalance() && B.sufficientBalance();
+
+  // Swap usdc for market tokens
+  const executeAction =
+    !connected
+      ? wallet.connect :
+      async () => {
+        if (A.account && B.account && A.mint && B.mint) {
+          setPendingTx(true);
+          issueSet(markets[0], parseAmount(1), wallet, connection)
+            .then(() => {
+              setPendingTx(true);
+              const components = [
+                {
+                  account: A.account,
+                  mintAddress: A.mintAddress,
+                  amount: A.convertAmount(),
+                },
+                {
+                  account: B.account,
+                  mintAddress: B.mintAddress,
+                  amount: B.convertAmount(),
+                },
+              ];
+
+              addLiquidity(connection, wallet, components, slippage, pool, options)
+                .then(() => {
+                  setPendingTx(false);
+                })
+                .catch((e) => {
+                  console.log("Transaction failed", e);
+                  notify({
+                    description:
+                      "Please try again and approve transactions from your wallet",
+                    message: "Adding liquidity cancelled.",
+                    type: "error",
+                  });
+                  setPendingTx(false);
+                });
+            })
+            .catch((e) => {
+              console.log("Transaction failed", e);
+              notify({
+                description:
+                  "Please try again and approve transactions from your wallet",
+                message: "Adding liquidity cancelled.",
+                type: "error",
+              });
+              setPendingTx(false);
+            });
+        }
+      }
+
+  const colStyle: React.CSSProperties = { padding: "1em" };
+
+
+  return (
+    <>
+      <div>
+        <CurrencyInput
+          title="Input"
+          onInputChange={(val: any) => {
+            setPoolOperation(PoolOperation.Add);
+            if (A.amount !== val) {
+              setLastTypedAccount(A.mintAddress);
+            }
+            A.setAmount(val);
+          }}
+          amount={A.amount}
+          mint={A.mintAddress}
+          onMintChange={(item) => {
+            A.setMint(item);
+          }}
+          forceMint={A.mintAddress}
+          renderOneTokenItem={A.mintAddress}
+        />
+
+        <Button
+          size="large"
+          type="primary"
+          onClick={executeAction}
+          disabled={
+            connected &&
+            (pendingTx ||
+              !A.account ||
+              !B.account ||
+              A.account === B.account ||
+              !hasSufficientBalance)
+          }
+        >
+          {generateActionLabel(ADD_LIQUIDITY_LABEL, connected, tokenMap, A, B)}
+          {pendingTx && <Spin indicator={antIcon} className="add-spinner" />}
+        </Button>
+
+      </div>
+    </>
+  );
+};

--- a/ui/src/components/addLiquidity.tsx
+++ b/ui/src/components/addLiquidity.tsx
@@ -103,39 +103,25 @@ export const AddLiquidityView = (props: {
       async () => {
         if (A.account && B.account && A.mint && B.mint) {
           setPendingTx(true);
-          let amount = parseAmount(A.amount);
-          if (!amount) {
-            return;
-          }
-          issueSet(markets[0], amount / 2, wallet, connection)
+          // @ts-ignore
+          issueSet(markets[0], parseAmount(A.amount) / 2, wallet, connection)
             .then(async () => {
               setPendingTx(true);
-              let components = [
+              const components = [
                 {
                   account: A.account,
                   mintAddress: A.mintAddress,
                   amount: A.convertAmount(),
                 },
                 {
-                  account: props.firstMintPK.account,
-                  mintAddress: props.firstMintPK.mintAddress,
-                  amount: props.firstMintPK.convertAmount(),
+                  account: B.account,
+                  mintAddress: B.mintAddress,
+                  amount: B.convertAmount(),
                 },
               ];
               fundPool(components, pool1);
-              components = [
-                {
-                  account: A.account,
-                  mintAddress: A.mintAddress,
-                  amount: A.convertAmount(),
-                },
-                {
-                  account: props.secondMintPK.account,
-                  mintAddress: props.secondMintPK.mintAddress,
-                  amount: props.secondMintPK.convertAmount(),
-                },
-              ];
-              fundPool(components, pool2);
+              B.setMint(props.secondMintPK)
+              // fundPool();
             })
             .catch((e) => {
               console.log("Transaction failed", e);

--- a/ui/src/components/currencyInput/index.tsx
+++ b/ui/src/components/currencyInput/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Card, Select } from "antd";
 import { NumericInput } from "../numericInput";
-import { getPoolName, getTokenName, isKnownMint } from "../../utils/utils";
+import { getPoolName, getTokenName, isKnownMint, KnownToken, } from "../../utils/utils";
 import {
   useUserAccounts,
   useMint,
@@ -73,6 +73,7 @@ export const CurrencyInput = (props: {
   onInputChange?: (val: number) => void;
   onMintChange?: (account: string) => void;
   forceMint?: string;
+  renderOneTokenItem?: string
 }) => {
   const { userAccounts } = useUserAccounts();
   const { pools } = useCachedPool();
@@ -84,6 +85,21 @@ export const CurrencyInput = (props: {
     tokens = tokens.filter(t => t.mintAddress === props.forceMint);
   }
 
+  let renderSingleToken: JSX.Element | undefined;
+  if (props.renderOneTokenItem) {
+    let mint = props.renderOneTokenItem;
+    let name = getTokenName(tokenMap, mint, true, 3);
+    let icon = <TokenIcon mintAddress={mint} />;
+    renderSingleToken = <Option key={mint} value={mint} name={name}>
+      <TokenDisplay
+        key={mint}
+        mintAddress={mint}
+        name={name}
+        icon={icon}
+        showBalance={true}
+      />
+    </Option>
+  }
   const renderPopularTokens = tokens.map((item) => {
     return (
       <Option
@@ -230,7 +246,7 @@ export const CurrencyInput = (props: {
               option?.name?.toLowerCase().indexOf(input.toLowerCase()) >= 0
             }
           >
-            {[...renderPopularTokens, ...renderAdditionalTokens]}
+            {renderSingleToken || [...renderPopularTokens, ...renderAdditionalTokens]}
           </Select>
         </div>
       </div>

--- a/ui/src/components/exchange.tsx
+++ b/ui/src/components/exchange.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button, Popover, Col, Row } from "antd";
 import { Settings } from "./settings";
 import { SettingOutlined } from "@ant-design/icons";
@@ -54,7 +54,7 @@ export const ExchangeView = (props: {}) => {
               <div style={colStyle}>
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
                   quoteMintAddress={market.outcomes[0].mint_pk} >
-                  <AddLiquidityView />
+                  <AddLiquidityView secondMintPK={market.outcomes[1]} firstMintPK={market.outcomes[0]} />
                 </CurrencyPairProvider>
               </div>
             </Col>

--- a/ui/src/components/exchange.tsx
+++ b/ui/src/components/exchange.tsx
@@ -34,6 +34,14 @@ export const ExchangeView = (props: {}) => {
       { markets.map((market: any) =>
         <>
           <Row justify="center">
+            <Col flex={0}>
+              <div style={colStyle}>
+
+                <AddLiquidityView market={market} baseMintAddress={market.quote_mint_pk} outcomes={market.outcomes} />
+              </div>
+            </Col>
+          </Row>
+          <Row justify="center">
             <Col flex={2}>
               <div style={colStyle}>
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
@@ -47,14 +55,6 @@ export const ExchangeView = (props: {}) => {
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
                   quoteMintAddress={market.outcomes[1].mint_pk} >
                   <SwapView />
-                </CurrencyPairProvider>
-              </div>
-            </Col>
-            <Col flex={0}>
-              <div style={colStyle}>
-                <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
-                  quoteMintAddress={market.outcomes[0].mint_pk} >
-                  <AddLiquidityView secondMintPK={market.outcomes[1]} firstMintPK={market.outcomes[0]} />
                 </CurrencyPairProvider>
               </div>
             </Col>

--- a/ui/src/components/exchange.tsx
+++ b/ui/src/components/exchange.tsx
@@ -5,42 +5,10 @@ import { SettingOutlined } from "@ant-design/icons";
 import { AppBar } from "./appBar";
 import { CurrencyPairProvider } from "../utils/currencyPair";
 import { SwapView } from "./swap";
-// Issue set helper
-import issueSet from '../utils/issueSet';
+import { AddLiquidityView } from "./addLiquidity";
 import { markets } from "../markets";
-// Connect to wallet
-import { useWallet } from '../utils/wallet';
-// Create connection to wallet
-import { useConnection } from '../utils/connection';
-// Our contract details
-import contract_keys from "../contract_keys.json";
-import { useMint } from '../utils/accounts';
-
-// TODO: Select market before making exchange
+// TODO: Allow market change before adding liquidity in case of multiple markets
 export const ExchangeView = (props: {}) => {
-  let connection = useConnection();
-  const { wallet } = useWallet();
-  // The mint address public key
-  const quoteMint = useMint(contract_keys.quote_mint_pk);
-
-  const parseAmount = (amount: any) => {
-  if(quoteMint) {
-    try {
-      return parseFloat(amount) * Math.pow(10, quoteMint.decimals);
-    } catch (error) {
-      // TODOl WHat to do here
-    }
-  } else {
-    // TODO: What to do here
-  }
-}
-
-  // Swap usdc for market tokens
-  const callIssueSet = async () => {
-    console.log('Market is ', markets[0])
-    await issueSet(markets[0], parseAmount(1), wallet, connection)
-}
-
   const colStyle: React.CSSProperties = { padding: "1em" };
 
 
@@ -63,13 +31,13 @@ export const ExchangeView = (props: {}) => {
           </Popover>
         }
       />
-        { markets.map((market: any) =>
-          <>
-            <Row justify="center">
+      { markets.map((market: any) =>
+        <>
+          <Row justify="center">
             <Col flex={2}>
               <div style={colStyle}>
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
-                                      quoteMintAddress={market.outcomes[0].mint_pk} >
+                  quoteMintAddress={market.outcomes[0].mint_pk} >
                   <SwapView />
                 </CurrencyPairProvider>
               </div>
@@ -77,19 +45,22 @@ export const ExchangeView = (props: {}) => {
             <Col flex={2}>
               <div style={colStyle}>
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
-                                      quoteMintAddress={market.outcomes[1].mint_pk} >
+                  quoteMintAddress={market.outcomes[1].mint_pk} >
                   <SwapView />
                 </CurrencyPairProvider>
               </div>
             </Col>
-            </Row>
-          </>
-        )}
-        <Button  shape="circle"
-              size="large"
-              type="text"
-              onClick={callIssueSet}
-              > Provide Liquidity</Button>
+            <Col flex={0}>
+              <div style={colStyle}>
+                <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
+                  quoteMintAddress={market.outcomes[0].mint_pk} >
+                  <AddLiquidityView />
+                </CurrencyPairProvider>
+              </div>
+            </Col>
+          </Row>
+        </>
+      )}
     </>
   );
 };

--- a/ui/src/components/exchange.tsx
+++ b/ui/src/components/exchange.tsx
@@ -5,10 +5,41 @@ import { SettingOutlined } from "@ant-design/icons";
 import { AppBar } from "./appBar";
 import { CurrencyPairProvider } from "../utils/currencyPair";
 import { SwapView } from "./swap";
-import contract_keys from "../contract_keys.json";
+// Issue set helper
+import issueSet from '../utils/issueSet';
 import { markets } from "../markets";
+// Connect to wallet
+import { useWallet } from '../utils/wallet';
+// Create connection to wallet
+import { useConnection } from '../utils/connection';
+// Our contract details
+import contract_keys from "../contract_keys.json";
+import { useMint } from '../utils/accounts';
 
+// TODO: Select market before making exchange
 export const ExchangeView = (props: {}) => {
+  let connection = useConnection();
+  const { wallet } = useWallet();
+  // The mint address public key
+  const quoteMint = useMint(contract_keys.quote_mint_pk);
+
+  const parseAmount = (amount: any) => {
+  if(quoteMint) {
+    try {
+      return parseFloat(amount) * Math.pow(10, quoteMint.decimals);
+    } catch (error) {
+      // TODOl WHat to do here
+    }
+  } else {
+    // TODO: What to do here
+  }
+}
+
+  // Swap usdc for market tokens
+  const callIssueSet = async () => {
+    console.log('Market is ', markets[0])
+    await issueSet(markets[0], parseAmount(1), wallet, connection)
+}
 
   const colStyle: React.CSSProperties = { padding: "1em" };
 
@@ -54,6 +85,11 @@ export const ExchangeView = (props: {}) => {
             </Row>
           </>
         )}
+        <Button  shape="circle"
+              size="large"
+              type="text"
+              onClick={callIssueSet}
+              > Provide Liquidity</Button>
     </>
   );
 };

--- a/ui/src/components/exchange.tsx
+++ b/ui/src/components/exchange.tsx
@@ -34,14 +34,6 @@ export const ExchangeView = (props: {}) => {
       { markets.map((market: any) =>
         <>
           <Row justify="center">
-            <Col flex={0}>
-              <div style={colStyle}>
-
-                <AddLiquidityView market={market} baseMintAddress={market.quote_mint_pk} outcomes={market.outcomes} />
-              </div>
-            </Col>
-          </Row>
-          <Row justify="center">
             <Col flex={2}>
               <div style={colStyle}>
                 <CurrencyPairProvider baseMintAddress={market.quote_mint_pk}
@@ -59,8 +51,16 @@ export const ExchangeView = (props: {}) => {
               </div>
             </Col>
           </Row>
+          <Row justify="center">
+            <Col flex={0}>
+              <div style={colStyle}>
+                <AddLiquidityView market={market} baseMintAddress={market.quote_mint_pk} outcomes={market.outcomes} />
+              </div>
+            </Col>
+          </Row>
         </>
-      )}
+      )
+      }
     </>
   );
 };

--- a/ui/src/components/redeem.jsx
+++ b/ui/src/components/redeem.jsx
@@ -22,6 +22,9 @@ import { markets } from "../markets";
 
 
 import { useMint } from '../utils/accounts';
+import { fetchAccounts, userTokenAccount } from '../utils/fetchAccounts';
+// For creating a token from usdc
+import issueSet from '../utils/issueSet';
 import { useConnection } from '../utils/connection';
 import { useWallet } from '../utils/wallet';
 import {sendTransaction} from "../utils/utils";
@@ -88,28 +91,6 @@ function encodeInstructionData(layout, args) {
   let data = Buffer.alloc(1024);
   const encodeLength = layout.encode(args, data);
   return data.slice(0, encodeLength);
-}
-
-function IssueSetInstruction(omegaContract, user, userQuote, vault, omegaSigner, outcomePks, quantity) {
-  let keys = [
-    { pubkey: omegaContract, isSigner: false, isWritable: false },
-    { pubkey: user, isSigner: true, isWritable: false },
-    { pubkey: userQuote, isSigner: false, isWritable: true },
-    { pubkey: vault, isSigner: false, isWritable: true },
-    { pubkey: TokenInstructions.TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
-    { pubkey: omegaSigner, isSigner: false, isWritable: false }
-  ];
-
-  for (var i = 0; i < outcomePks.length; i++) {
-    keys.push({pubkey: outcomePks[i], isSigner: false, isWritable: true});
-  }
-
-  const data = encodeInstructionData(instructionLayout, {
-    instruction: IC_ISSUE_SET,
-    quantity
-  });
-
-  return new TransactionInstruction({keys: keys, programId: PROGRAM_ID, data: data});
 }
 
 function RedeemSetInstruction(omegaContract, user, userQuote, vault, omegaSigner, outcomePks, quantity) {
@@ -184,24 +165,6 @@ export const RedeemView = (props) => {
     console.log('contract.decided', contractData.decided);
   }, [contractData]);
 
-
-  async function fetchAccounts() {
-    console.log('Fetch all SPL tokens for', wallet.publicKey.toString());
-
-    const response = await connection.getParsedTokenAccountsByOwner(
-      wallet.publicKey,
-      { programId: TokenInstructions.TOKEN_PROGRAM_ID }
-    );
-
-    console.log(response.value.length, 'SPL tokens found', response);
-
-    response.value.map((a) => a.account.data.parsed.info).forEach((info, _) => {
-      console.log(info.mint, info.tokenAmount.uiAmount);
-    });
-
-    return response.value;
-  }
-
   async function createTokenAccountTransaction(mintPubkey) {
     const newAccount = new Account();
     const transaction = new Transaction();
@@ -230,92 +193,23 @@ export const RedeemView = (props) => {
     };
   }
 
-  async function userTokenAccount(accounts, mintPubkey) {
-    let account = accounts.find(a => a.account.data.parsed.info.mint === mintPubkey.toBase58())
-    if (account) {
-      console.log('account exists', mintPubkey.toString(), account.pubkey.toString());
-      return account.pubkey;
-    } else {
-      console.log('creating new account for', mintPubkey.toString());
-      let { transaction, signer, newAccountPubkey } = await createTokenAccountTransaction(mintPubkey);
-
-      let signers = [signer]
-
-      const instrStr = 'create account'
-      let txid = await sendTransaction({
-        transaction,
-        wallet,
-        signers,
-        connection,
-        sendingMessage: `sending ${instrStr}...`,
-        sentMessage: `${instrStr} sent`,
-        successMessage: `${instrStr} success`
-      });
-      console.log("txid", txid);
-      console.log('pubkey', newAccountPubkey.toString());
-
-      return newAccountPubkey;
-    }
-  }
-
   function parseAmount(amount) {
     return parseFloat(amount) * Math.pow(10, quoteMint.decimals);
   }
-
-  async function issueSet(market, amount) {
-
-    if (!wallet.connected) await wallet.connect();
-    console.log('issueSet', amount);
-
-    const accounts = await fetchAccounts();
-
-    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT);
-    let outcomePks = [];
-    let outcomeInfos = market["outcomes"];
-    let numOutcomes = outcomeInfos.length;
-    for (let i = 0; i < numOutcomes; i++) {
-      let outcomeMint = new PublicKey(outcomeInfos[i]["mint_pk"]);
-      outcomePks.push(outcomeMint);
-      let userOutcomeWallet = await userTokenAccount(accounts, outcomeMint);
-      outcomePks.push(userOutcomeWallet);
-      console.log(outcomeInfos[i]["name"], outcomeMint, userOutcomeWallet);
-    }
-    let issueSetInstruction = IssueSetInstruction(
-      new PublicKey(market.omega_contract_pk),
-      wallet.publicKey,
-      userQuote,
-      new PublicKey(market.quote_vault_pk),
-      new PublicKey(market.signer_pk),
-      outcomePks,
-      amount);
-    let transaction = new Transaction();
-    transaction.add(issueSetInstruction);
-
-    let txid = await sendTransaction({
-      transaction,
-      wallet,
-      signers: [],
-      connection,
-      sendingMessage: 'sending IssueSetInstruction...',
-      sentMessage: 'IssueSetInstruction sent',
-      successMessage: 'IssueSetInstruction success'
-    });
-    console.log('success txid:', txid);
-  }
-
+  
   async function redeemSet(market, amount) {
     if (!wallet.connected) await wallet.connect();
     console.log('redeemSet', amount);
-    const accounts = await fetchAccounts();
+    const accounts = await fetchAccounts(wallet, connection);
 
-    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT);
+    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT, wallet, connection);
     let outcomePks = [];
     let outcomeInfos = market["outcomes"];
     let numOutcomes = outcomeInfos.length;
     for (let i = 0; i < numOutcomes; i++) {
       let outcomeMint = new PublicKey(outcomeInfos[i]["mint_pk"]);
       outcomePks.push(outcomeMint);
-      let userOutcomeWallet = await userTokenAccount(accounts, outcomeMint);
+      let userOutcomeWallet = await userTokenAccount(accounts, outcomeMint, wallet, connection);
       outcomePks.push(userOutcomeWallet);
       console.log(outcomeInfos[i]["name"], outcomeMint, userOutcomeWallet);
     }
@@ -346,7 +240,7 @@ export const RedeemView = (props) => {
     if (!wallet.connected) await wallet.connect();
     console.log('redeemWinner', amount);
 
-    const accounts = await fetchAccounts();
+    const accounts = await fetchAccounts(wallet, connection);
     let winner = new PublicKey(contractData.winner);
     console.log(winner);
     let zeroPubkey = new PublicKey(new Uint8Array(32));
@@ -356,8 +250,8 @@ export const RedeemView = (props) => {
       return;
     }
 
-    let winnerWallet = await userTokenAccount(accounts, winner);
-    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT);
+    let winnerWallet = await userTokenAccount(accounts, winner, wallet, connection);
+    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT, wallet, connection);
 
     let redeemWinnerInstruction = RedeemWinnerInstruction(
       new PublicKey(market.omega_contract_pk),
@@ -502,7 +396,7 @@ export const RedeemView = (props) => {
                   <Button
                     className="trade-button"
                     type="primary"
-                    onClick={connected ? () => issueSet(issueMarket, parseAmount(issueAmount)) : wallet.connect}
+                    onClick={connected ? () => issueSet(issueMarket, parseAmount(issueAmount), wallet, connection) : wallet.connect}
                     style={{ width: "100%" }}
                   >
                     { connected ? "Issue Tokens" : "Connect Wallet" }

--- a/ui/src/components/redeem.jsx
+++ b/ui/src/components/redeem.jsx
@@ -78,7 +78,6 @@ async function queryMarketContract(conn, contract) {
 
 
 
-const IC_ISSUE_SET = 1;
 const IC_REDEEM_SET = 2;
 const IC_REDEEM_WINNER = 3;
 

--- a/ui/src/components/swap.tsx
+++ b/ui/src/components/swap.tsx
@@ -1,46 +1,19 @@
 import React, { useState } from "react";
-import { Card  } from "antd";
+import { Card } from "antd";
 import { TradeEntry } from "./trade";
 import { AddToLiquidity } from "./pool/add";
 
 export const SwapView = (props: {}) => {
-  const tabStyle: React.CSSProperties = { width: 120 };
-  const tabList = [
-    {
-      key: "trade",
-      tab: <div style={tabStyle}>Trade</div>,
-      render: () => {
-        return <TradeEntry />;
-      },
-    },
-    {
-      key: "pool",
-      tab: <div style={tabStyle}>Pool</div>,
-      render: () => {
-        return <AddToLiquidity />;
-      },
-    },
-  ];
-
-  const [activeTab, setActiveTab] = useState(tabList[0].key);
-
   return (
     <>
-        <Card
-          className="exchange-card"
-          headStyle={{ padding: 0 }}
-          bodyStyle={{ position: "relative" }}
-          tabList={tabList}
-          tabProps={{
-            tabBarGutter: 0,
-          }}
-          activeTabKey={activeTab}
-          onTabChange={(key) => {
-            setActiveTab(key);
-          }}
-        >
-          {tabList.find((t) => t.key === activeTab)?.render()}
-        </Card>
+      <Card
+        className="exchange-card"
+        headStyle={{ padding: 0 }}
+        bodyStyle={{ position: "relative" }}
+      >
+        <div style={{ fontSize: '1.5rem', color: '#2ABDD2' }}>Trade</div>
+        <TradeEntry />
+      </Card>
     </>);
 };
 

--- a/ui/src/markets/kc.json
+++ b/ui/src/markets/kc.json
@@ -1,23 +1,23 @@
 {
   "contract_name": "SUPERBOWL21",
   "details": "None",
-  "omega_contract_pk": "Cfrq9xBMVVG5dW7FQvr6KQVovrn4uwvXFBYRwJHDkDAS",
+  "omega_contract_pk": "DWidHAaZYzzJcqpnRTsdpKXbhvP4jBxHhpsLaB1JkMVa",
   "omega_program_id": "E9LcZwiT8f9REGn4wmastVb2rJHCMfRSSKUQzgiUEdJT",
-  "oracle_pk": "FinVobfi4tbdMdfN9jhzUuDVqGXfcFnRGX57xHcTWLfW",
+  "oracle_pk": "FJpmfVUmd75kVieMjBLixdk5611xvXVUNadhcSbhE4Hm",
   "outcomes": [
     {
       "icon": "/markets/SUPERBOWL21/kc.png",
-      "mint_pk": "BPS8Rn7wxvsVDxhof5fgahwiP3SfR95FTP2mVhFwCGUs",
+      "mint_pk": "4rsvtduTWQiiaJ8amFkPwByCguEAKtKjzZACy74RVu4X",
       "name": "KC"
     },
     {
       "icon": "/markets/SUPERBOWL21/tb.png",
-      "mint_pk": "9AWpaa7SVeAeftVn9AmW3Ywzsxk6eLG2WJuyE3z3iRNb",
+      "mint_pk": "5nT87iMu58ojGgW4qUYKiQ3CmV14udYwbrwHJxAEiyc2",
       "name": "TB"
     }
   ],
-  "quote_mint_pk": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "quote_vault_pk": "8m26Hhu5pdf2EDmhwssHCSVucZFGW7RTgfXf5qyFCyBR",
-  "signer_nonce": 2,
-  "signer_pk": "9cA3tWHvCPqVBeM1QWvPYZaxuTncakTwgMvR7ESLi9VP"
+  "quote_mint_pk": "Fq939Y5hycK62ZGwBjftLY2VyxqAQ8f1MxRqBMdAaBS7",
+  "quote_vault_pk": "DN7U6ezYTgQVvL35QCodmaQGSkRaFWb1B5EjUAtCNC9K",
+  "signer_nonce": 0,
+  "signer_pk": "7RPgJ5wMVjFMRmyGGMS5wD68dPxBkofAV8kCDo9pKv7V"
 }

--- a/ui/src/utils/currencyPair.tsx
+++ b/ui/src/utils/currencyPair.tsx
@@ -77,9 +77,9 @@ export const useCurrencyLeg = (defaultMint?: string) => {
 };
 
 export function CurrencyPairProvider({
-    baseMintAddress = "" as string,
-    quoteMintAddress = "" as string,
-    children = null as any }) {
+  baseMintAddress = "" as string,
+  quoteMintAddress = "" as string,
+  children = null as any }) {
 
   const connection = useConnection();
   const { tokens } = useConnectionConfig();
@@ -108,27 +108,27 @@ export function CurrencyPairProvider({
   // disabled: doesn't work well with multiple swaps on the same page
   // updates browser history on token changes
   //useEffect(() => {
-    //// set history
-    //const base =
-      //tokens.find((t) => t.mintAddress === mintAddressA)?.tokenSymbol ||
-      //mintAddressA;
-    //const quote =
-      //tokens.find((t) => t.mintAddress === mintAddressB)?.tokenSymbol ||
-      //mintAddressB;
+  //// set history
+  //const base =
+  //tokens.find((t) => t.mintAddress === mintAddressA)?.tokenSymbol ||
+  //mintAddressA;
+  //const quote =
+  //tokens.find((t) => t.mintAddress === mintAddressB)?.tokenSymbol ||
+  //mintAddressB;
 
-    //if (base && quote && location.pathname.indexOf("info") < 0) {
-      //history.push({
-        //search: `?pair=${base}-${quote}`,
-      //});
-    //} else {
-      //if (mintAddressA && mintAddressB) {
-        //history.push({
-          //search: ``,
-        //});
-      //} else {
-        //return;
-      //}
-    //}
+  //if (base && quote && location.pathname.indexOf("info") < 0) {
+  //history.push({
+  //search: `?pair=${base}-${quote}`,
+  //});
+  //} else {
+  //if (mintAddressA && mintAddressB) {
+  //history.push({
+  //search: ``,
+  //});
+  //} else {
+  //return;
+  //}
+  //}
   //}, [mintAddressA, mintAddressB, tokens, history, location.pathname]);
 
   // Updates tokens on location change
@@ -147,13 +147,13 @@ export function CurrencyPairProvider({
 
     setMintAddressA(
       tokens.find((t) => t.tokenSymbol === defaultBase)?.mintAddress ||
-        (isValidAddress(defaultBase) ? defaultBase : "") ||
-        ""
+      (isValidAddress(defaultBase) ? defaultBase : "") ||
+      ""
     );
     setMintAddressB(
       tokens.find((t) => t.tokenSymbol === defaultQuote)?.mintAddress ||
-        (isValidAddress(defaultQuote) ? defaultQuote : "") ||
-        ""
+      (isValidAddress(defaultQuote) ? defaultQuote : "") ||
+      ""
     );
     // mintAddressA and mintAddressB are not included here to prevent infinite loop
     // eslint-disable-next-line

--- a/ui/src/utils/fetchAccounts.tsx
+++ b/ui/src/utils/fetchAccounts.tsx
@@ -1,0 +1,108 @@
+// This helper class fetches all token accounts from  wallet
+// TODO: Check if to pass in an instruction class instead
+// Import our token instruction class
+import { TokenInstructions } from '@project-serum/serum';
+// Linting
+import { Connection, PublicKey } from '@solana/web3.js';
+// For creating a new account
+import {
+  Account,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js';
+import {AccountLayout} from '@solana/spl-token';
+// Initiate a transaction
+import {sendTransaction} from "../utils/utils";
+
+
+/**
+ * 
+ * @param wallet The wallet from which the account is to be imported
+ * @param connection The connection object to the account
+ * @returns Promise<Array>
+ */
+export async function fetchAccounts(wallet: any, connection: Connection): Promise<any> {
+    console.log('Fetch all SPL tokens for', wallet.publicKey.toString());
+
+    const response = await connection.getParsedTokenAccountsByOwner(
+      wallet.publicKey,
+      { programId: TokenInstructions.TOKEN_PROGRAM_ID }
+    );
+
+    console.log(response.value.length, 'SPL tokens found', response);
+
+    response.value.map((a) => a.account.data.parsed.info).forEach((info, _) => {
+      console.log(info.mint, info.tokenAmount.uiAmount);
+    });
+
+    return response.value;
+  }
+
+
+  /**
+   * 
+   * @param accounts The user accounts
+   * @param mintPubkey The public key of the account where the outcome tokens resides
+   * @returns Promise<String>
+   */
+  export async function userTokenAccount(accounts: Array<any>, mintPubkey: PublicKey, wallet: any, connection: Connection) {
+    let account = accounts.find(a => a.account.data.parsed.info.mint === mintPubkey.toBase58())
+    if (account) {
+      console.log('account exists', mintPubkey.toString(), account.pubkey.toString());
+      return account.pubkey;
+    } else {
+      console.log('creating new account for', mintPubkey.toString());
+      let { transaction, signer, newAccountPubkey } = await createTokenAccountTransaction(mintPubkey, connection, wallet);
+
+      let signers = [signer]
+
+      const instrStr = 'create account'
+      let txid = await sendTransaction({
+        transaction,
+        wallet,
+        signers,
+        connection,
+        sendingMessage: `sending ${instrStr}...`,
+        sentMessage: `${instrStr} sent`,
+        successMessage: `${instrStr} success`
+      });
+      console.log("txid", txid);
+      console.log('pubkey', newAccountPubkey.toString());
+
+      return newAccountPubkey;
+    }
+  }
+
+  /**
+   * 
+   * @param mintPubkey The account where tokens are minted to
+   * @param connection Connection to the account
+   * @param wallet The users wallet
+   */
+async function createTokenAccountTransaction(mintPubkey: PublicKey, connection: Connection, wallet: any) {
+    const newAccount = new Account();
+    const transaction = new Transaction();
+    transaction.add(
+      SystemProgram.createAccount({
+        fromPubkey: wallet.publicKey,
+        newAccountPubkey: newAccount.publicKey,
+        lamports: await connection.getMinimumBalanceForRentExemption(AccountLayout.span),
+        space: AccountLayout.span,
+        programId: TokenInstructions.TOKEN_PROGRAM_ID,
+      })
+    );
+
+    transaction.add(
+      TokenInstructions.initializeAccount({
+        account: newAccount.publicKey,
+        mint: mintPubkey,
+        owner: wallet.publicKey,
+      }),
+    );
+
+    return {
+      transaction,
+      signer: newAccount,
+      newAccountPubkey: newAccount.publicKey,
+    };
+  }

--- a/ui/src/utils/issueSet.tsx
+++ b/ui/src/utils/issueSet.tsx
@@ -1,0 +1,115 @@
+// This util file contains helper functions
+// for creating outcome tokens from usdc
+// Import our token instruction class
+import { TokenInstructions } from '@project-serum/serum';
+// Setup transaction instruction
+import {
+  TransactionInstruction,
+  PublicKey,
+  Connection,
+  Transaction
+} from '@solana/web3.js';
+// Our program id
+import contract_keys from "../contract_keys.json";
+// For creating instruction layout
+import BufferLayout from 'buffer-layout';
+// Initiate transaction
+import {sendTransaction} from "../utils/utils";
+// Account utils
+import { fetchAccounts, userTokenAccount } from './fetchAccounts'
+
+// Issue set identifier 
+const IC_ISSUE_SET = 1;
+
+// Layout of instruction
+const instructionLayout = BufferLayout.struct([
+  BufferLayout.u32('instruction'),
+  BufferLayout.nu64('quantity'),
+]);
+
+// Our deployed program id
+const PROGRAM_ID = new PublicKey(contract_keys.omega_program_id);
+
+const QUOTE_CURRENCY_MINT = new PublicKey(contract_keys.quote_mint_pk);
+
+function IssueSetInstruction(omegaContract: any, user: any, userQuote: any, vault: any, omegaSigner: any, outcomePks: any, quantity: any) {
+  let keys = [
+    { pubkey: omegaContract, isSigner: false, isWritable: false },
+    { pubkey: user, isSigner: true, isWritable: false },
+    { pubkey: userQuote, isSigner: false, isWritable: true },
+    { pubkey: vault, isSigner: false, isWritable: true },
+    { pubkey: TokenInstructions.TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: omegaSigner, isSigner: false, isWritable: false }
+  ];
+
+  for (var i = 0; i < outcomePks.length; i++) {
+    keys.push({pubkey: outcomePks[i], isSigner: false, isWritable: true});
+  }
+
+  const data = encodeInstructionData(instructionLayout, {
+    instruction: IC_ISSUE_SET,
+    quantity
+  });
+
+  return new TransactionInstruction({keys: keys, programId: PROGRAM_ID, data: data});
+}
+
+/**
+ * @summary Create instruction layout
+ * @param layout 
+ * @param args 
+ */
+function encodeInstructionData(layout: typeof instructionLayout, args: any) {
+  let data = Buffer.alloc(1024);
+  const encodeLength = layout.encode(args, data);
+  return data.slice(0, encodeLength);
+}
+
+/**
+ * 
+ * @param market 
+ * @param amount Amount to issue
+ * @param wallet Wallet to bill from
+ * @param connection THe connection object
+ */
+  async function issueSet(market: any, amount: any, wallet: any, connection: Connection) {
+    if (!wallet.connected) await wallet.connect();
+    console.log('issueSet', amount);
+
+    const accounts = await fetchAccounts(wallet, connection);
+
+    let userQuote = await userTokenAccount(accounts, QUOTE_CURRENCY_MINT, wallet, connection);
+    let outcomePks = [];
+    let outcomeInfos = market["outcomes"];
+    let numOutcomes = outcomeInfos.length;
+    for (let i = 0; i < numOutcomes; i++) {
+      let outcomeMint = new PublicKey(outcomeInfos[i]["mint_pk"]);
+      outcomePks.push(outcomeMint);
+      let userOutcomeWallet = await userTokenAccount(accounts, outcomeMint, wallet, connection);
+      outcomePks.push(userOutcomeWallet);
+      console.log(outcomeInfos[i]["name"], outcomeMint, userOutcomeWallet);
+    }
+    let issueSetInstruction = IssueSetInstruction(
+      new PublicKey(market.omega_contract_pk),
+      wallet.publicKey,
+      userQuote,
+      new PublicKey(market.quote_vault_pk),
+      new PublicKey(market.signer_pk),
+      outcomePks,
+      amount);
+    let transaction = new Transaction();
+    transaction.add(issueSetInstruction);
+
+    let txid = await sendTransaction({
+      transaction,
+      wallet,
+      signers: [],
+      connection,
+      sendingMessage: 'sending IssueSetInstruction...',
+      sentMessage: 'IssueSetInstruction sent',
+      successMessage: 'IssueSetInstruction success'
+    });
+    console.log('success txid:', txid);
+  }
+
+  export default issueSet;

--- a/ui/src/utils/pools.tsx
+++ b/ui/src/utils/pools.tsx
@@ -505,21 +505,26 @@ async function getMultipleAccounts(
 
 ): Promise<{ publicKey: string; accountInfo: AccountInfo<Buffer> }[]> {
 
-  // @ts-ignore
-  const resp = await connection._rpcRequest('getMultipleAccounts', [publicKeyStrs]);
-  if (resp.error) {
-    throw new Error(resp.error.message);
-  }
+
 
   const filtPubkeys: string[] = []
   const filtData: any[] = []
 
-  for (let i = 0; i < resp.result.value.length; i++) {
-    if (resp.result.value[i] === null) {
-      console.log("NULL ACCOUNT", resp.result.value[i], publicKeyStrs[i])
-    } else {
-      filtPubkeys.push(publicKeyStrs[i])
-      filtData.push(resp.result.value[i])
+  for (let i = 0; i < Math.ceil(publicKeyStrs.length / 100); i++) {
+
+    let batchKeys = publicKeyStrs.slice(i * 100, Math.min((i + 1) * 100, publicKeyStrs.length));
+    // @ts-ignore
+    const resp = await connection._rpcRequest('getMultipleAccounts', [batchKeys]);
+    if (resp.error) {
+      throw new Error(resp.error.message);
+    }
+    for (let j = 0; j < resp.result.value.length; j++) {
+      if (resp.result.value[j] === null) {
+        console.log("NULL ACCOUNT", resp.result.value[j], batchKeys[j])
+      } else {
+        filtPubkeys.push(batchKeys[j])
+        filtData.push(resp.result.value[j])
+      }
     }
   }
 
@@ -535,6 +540,7 @@ async function getMultipleAccounts(
       },
     }),
   );
+
 }
 
 export const usePoolForBasket = (mints: (string | undefined)[]) => {


### PR DESCRIPTION
Currently providing liquidity is a multi-step process, that requires understanding of the pool mechanics. A user has to:

1.Decide on how many USDC they want to provide
2.Convert 50% of it into an outcome set using "Issue Set"
3.Provide liquidity to each pool using all the issued tokens + the value of those tokens in USDC

4.This action could be simplified into a single input & action button right on the "Predict" page of the market.

 

- [ x] Add a section on the "Exchange" page below "Provide Liquidity" with an input box for the user to input the USDC amount

 
 The current liquidity provided is displayed on the same page as a single USDC amount

 

- [ x] Allow providing liquidity if the pool has been created already, but the user never interacted with the pool